### PR TITLE
docs(readme): clarify data freshness, add Tools section

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "MD013": false,
+  "MD060": {
+    "style": "leading_and_trailing"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -190,6 +190,25 @@ The database is **shared** across all your projects by default (recommended):
 
 **Dev mode (`--dev`)**: Only use this if you're developing the jlcpcb-mcp package itself. It creates a separate database in `./data/` which is useful for testing but wastes space for normal usage.
 
+#### Data Freshness
+
+This server uses a **hybrid** approach — a local catalog snapshot for fast search, plus live API calls for stock and pricing.
+
+| Data | Source | Freshness |
+|------|--------|-----------|
+| Component catalog (descriptions, packages, attributes, categories) | Local SQLite, built from [yaqwsx/jlcparts](https://github.com/yaqwsx/jlcparts) | Snapshot from your last refresh |
+| Stock levels | Live JLCPCB API (`wmsc.lcsc.com`) | Real-time, per query |
+| Pricing tiers | Live JLCPCB API | Real-time, per query |
+| Datasheet URL | Live JLCPCB API | Real-time, per query |
+
+The local catalog does **not** auto-update. Refresh it periodically to pick up newly-added parts, removed parts, and metadata changes:
+
+```bash
+jlcpcb-mcp-setup --refresh-db
+```
+
+For most workflows, refreshing weekly or monthly is sufficient. Stock and price decisions are always made against live data, so you don't need a fresh catalog to trust the numbers on parts you already know.
+
 ## License
 
 MIT License - see LICENSE file for details

--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ All of these are aluminum electrolytic SMD capacitors rated for 16V, which gives
 
 Note: These are all Extended parts (not Basic), so they will incur additional assembly fees if you're using JLCPCB assembly.
 
+## Tools
+
+The MCP server exposes four tools to your AI assistant:
+
+| Tool | What it does |
+|------|--------------|
+| `search_components` | Keyword search across the catalog. Optional filters: `category`, `package`, `basic_only`, `min_stock`, `max_results`. |
+| `get_component_details` | Full live details for an LCSC part — current stock, pricing tiers, full parameter list, datasheet, and images. |
+| `database_status` | Reports the local database location, size, and component count. |
+| `refresh_database` | Re-downloads the catalog snapshot from inside the chat — no CLI needed. |
+
+Most of the time you don't call these directly; you ask Claude in natural language ("find me a 10k 0805 resistor with at least 5k in stock") and it picks the right tool.
+
 ## Installation
 
 ### From PyPI

--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ The MCP server exposes four tools to your AI assistant:
 
 Most of the time you don't call these directly; you ask Claude in natural language ("find me a 10k 0805 resistor with at least 5k in stock") and it picks the right tool.
 
+## Data Freshness
+
+This server uses a **hybrid** approach — a local catalog snapshot for fast search, plus live API calls for stock and pricing.
+
+| Data | Source | Freshness |
+|------|--------|-----------|
+| Component catalog (descriptions, packages, attributes, categories) | Local SQLite, built from [yaqwsx/jlcparts](https://github.com/yaqwsx/jlcparts) | Snapshot from your last refresh |
+| Stock levels | Live JLCPCB API (`wmsc.lcsc.com`) | Real-time, per query |
+| Pricing tiers | Live JLCPCB API | Real-time, per query |
+| Datasheet URL | Live JLCPCB API | Real-time, per query |
+
+The local catalog does **not** auto-update. Refresh it periodically to pick up newly-added parts, removed parts, and metadata changes:
+
+```bash
+jlcpcb-mcp-setup --refresh-db
+```
+
+For most workflows, refreshing weekly or monthly is sufficient. Stock and price decisions are always made against live data, so you don't need a fresh catalog to trust the numbers on parts you already know.
+
 ## Installation
 
 ### From PyPI
@@ -202,25 +221,6 @@ The database is **shared** across all your projects by default (recommended):
 - Easier to keep updated
 
 **Dev mode (`--dev`)**: Only use this if you're developing the jlcpcb-mcp package itself. It creates a separate database in `./data/` which is useful for testing but wastes space for normal usage.
-
-#### Data Freshness
-
-This server uses a **hybrid** approach — a local catalog snapshot for fast search, plus live API calls for stock and pricing.
-
-| Data | Source | Freshness |
-|------|--------|-----------|
-| Component catalog (descriptions, packages, attributes, categories) | Local SQLite, built from [yaqwsx/jlcparts](https://github.com/yaqwsx/jlcparts) | Snapshot from your last refresh |
-| Stock levels | Live JLCPCB API (`wmsc.lcsc.com`) | Real-time, per query |
-| Pricing tiers | Live JLCPCB API | Real-time, per query |
-| Datasheet URL | Live JLCPCB API | Real-time, per query |
-
-The local catalog does **not** auto-update. Refresh it periodically to pick up newly-added parts, removed parts, and metadata changes:
-
-```bash
-jlcpcb-mcp-setup --refresh-db
-```
-
-For most workflows, refreshing weekly or monthly is sufficient. Stock and price decisions are always made against live data, so you don't need a fresh catalog to trust the numbers on parts you already know.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ Note: These are all Extended parts (not Basic), so they will incur additional as
 
 The MCP server exposes four tools to your AI assistant:
 
-|Tool|What it does|
-|----|------------|
-|`search_components`|Keyword search across the catalog. Optional filters: `category`, `package`, `basic_only`, `min_stock`, `max_results`.|
-|`get_component_details`|Full live details for an LCSC part — current stock, pricing tiers, full parameter list, datasheet, and images.|
-|`database_status`|Reports the local database location, size, and component count.|
-|`refresh_database`|Re-downloads the catalog snapshot from inside the chat — no CLI needed.|
+| Tool | What it does |
+|------|--------------|
+| `search_components` | Keyword search across the catalog. Optional filters: `category`, `package`, `basic_only`, `min_stock`, `max_results`. |
+| `get_component_details` | Full live details for an LCSC part — current stock, pricing tiers, full parameter list, datasheet, and images. |
+| `database_status` | Reports the local database location, size, and component count. |
+| `refresh_database` | Re-downloads the catalog snapshot from inside the chat — no CLI needed. |
 
 Most of the time you don't call these directly; you ask Claude in natural language ("find me a 10k 0805 resistor with at least 5k in stock") and it picks the right tool.
 
@@ -207,12 +207,12 @@ The database is **shared** across all your projects by default (recommended):
 
 This server uses a **hybrid** approach — a local catalog snapshot for fast search, plus live API calls for stock and pricing.
 
-|Data|Source|Freshness|
-|----|------|---------|
-|Component catalog (descriptions, packages, attributes, categories)|Local SQLite, built from [yaqwsx/jlcparts](https://github.com/yaqwsx/jlcparts)|Snapshot from your last refresh|
-|Stock levels|Live JLCPCB API (`wmsc.lcsc.com`)|Real-time, per query|
-|Pricing tiers|Live JLCPCB API|Real-time, per query|
-|Datasheet URL|Live JLCPCB API|Real-time, per query|
+| Data | Source | Freshness |
+|------|--------|-----------|
+| Component catalog (descriptions, packages, attributes, categories) | Local SQLite, built from [yaqwsx/jlcparts](https://github.com/yaqwsx/jlcparts) | Snapshot from your last refresh |
+| Stock levels | Live JLCPCB API (`wmsc.lcsc.com`) | Real-time, per query |
+| Pricing tiers | Live JLCPCB API | Real-time, per query |
+| Datasheet URL | Live JLCPCB API | Real-time, per query |
 
 The local catalog does **not** auto-update. Refresh it periodically to pick up newly-added parts, removed parts, and metadata changes:
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ Note: These are all Extended parts (not Basic), so they will incur additional as
 
 The MCP server exposes four tools to your AI assistant:
 
-| Tool | What it does |
-|------|--------------|
-| `search_components` | Keyword search across the catalog. Optional filters: `category`, `package`, `basic_only`, `min_stock`, `max_results`. |
-| `get_component_details` | Full live details for an LCSC part — current stock, pricing tiers, full parameter list, datasheet, and images. |
-| `database_status` | Reports the local database location, size, and component count. |
-| `refresh_database` | Re-downloads the catalog snapshot from inside the chat — no CLI needed. |
+|Tool|What it does|
+|----|------------|
+|`search_components`|Keyword search across the catalog. Optional filters: `category`, `package`, `basic_only`, `min_stock`, `max_results`.|
+|`get_component_details`|Full live details for an LCSC part — current stock, pricing tiers, full parameter list, datasheet, and images.|
+|`database_status`|Reports the local database location, size, and component count.|
+|`refresh_database`|Re-downloads the catalog snapshot from inside the chat — no CLI needed.|
 
 Most of the time you don't call these directly; you ask Claude in natural language ("find me a 10k 0805 resistor with at least 5k in stock") and it picks the right tool.
 
@@ -207,12 +207,12 @@ The database is **shared** across all your projects by default (recommended):
 
 This server uses a **hybrid** approach — a local catalog snapshot for fast search, plus live API calls for stock and pricing.
 
-| Data | Source | Freshness |
-|------|--------|-----------|
-| Component catalog (descriptions, packages, attributes, categories) | Local SQLite, built from [yaqwsx/jlcparts](https://github.com/yaqwsx/jlcparts) | Snapshot from your last refresh |
-| Stock levels | Live JLCPCB API (`wmsc.lcsc.com`) | Real-time, per query |
-| Pricing tiers | Live JLCPCB API | Real-time, per query |
-| Datasheet URL | Live JLCPCB API | Real-time, per query |
+|Data|Source|Freshness|
+|----|------|---------|
+|Component catalog (descriptions, packages, attributes, categories)|Local SQLite, built from [yaqwsx/jlcparts](https://github.com/yaqwsx/jlcparts)|Snapshot from your last refresh|
+|Stock levels|Live JLCPCB API (`wmsc.lcsc.com`)|Real-time, per query|
+|Pricing tiers|Live JLCPCB API|Real-time, per query|
+|Datasheet URL|Live JLCPCB API|Real-time, per query|
 
 The local catalog does **not** auto-update. Refresh it periodically to pick up newly-added parts, removed parts, and metadata changes:
 


### PR DESCRIPTION
## Summary

- Adds a **Data Freshness** section explaining the hybrid local-catalog + live-API model and pointing users at `--refresh-db` for catalog updates. Resolves the question raised in #1.
- Adds a **Tools** section listing the four MCP tools (`search_components`, `get_component_details`, `database_status`, `refresh_database`) — `refresh_database` was previously only documented as a CLI flag.
- Adds a project-level `.markdownlint.json` that pins the readable table style and disables MD013 (line-length); the README is intentionally prose-formatted.

## Test plan

- [ ] Render README on GitHub and confirm both new sections (Tools, Data Freshness) appear at H2 in the TOC
- [ ] Confirm both tables render correctly
- [ ] Confirm `.markdownlint.json` quiets the IDE warnings on the new tables

Refs #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)