### PR TITLE
fix(database): port to upstream manifest+LUT+shards format

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,10 +198,10 @@ uv run jlcpcb-mcp-setup --refresh-db
 
 **What to expect:**
 
-- **Download**: ~50MB compressed data (1,268 categories)
-- **Final size**: ~917MB SQLite database uncompressed
-- **Time**: ~3 minutes on fast internet connection (500Mbps), up to 10 minutes on slower connections
-- **Progress**: Real-time updates showing download progress and category processing
+- **Download**: ~50MB compressed (manifest + attributes lookup table + ~1,294 per-subcategory shards)
+- **Final size**: ~1.8GB SQLite database uncompressed (~576k components, 1,289 subcategories)
+- **Time**: ~4 minutes on fast internet connection (500Mbps), up to 10 minutes on slower connections
+- **Progress**: Real-time updates showing download progress and subcategory processing
 
 If you don't pre-download, **your first Claude query will trigger the download automatically**, so expect a 3-10 minute wait.
 

--- a/src/jlcpcb_mcp/database.py
+++ b/src/jlcpcb_mcp/database.py
@@ -3,8 +3,10 @@
 import gzip
 import json
 import os
+import random
 import sqlite3
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -20,6 +22,13 @@ class DatabaseManager:
     MANIFEST_FILENAME = "manifest.json"
     ATTR_LUT_FILENAME = "attributes-lut.json.gz"
     MANIFEST_VERSION = 2
+
+    # HTTP retry policy for upstream fetches. Connection errors and 5xx responses
+    # retry with exponential backoff + jitter; 4xx responses fail fast (404 means
+    # the file is gone, not transiently unavailable).
+    HTTP_RETRY_ATTEMPTS = 3
+    HTTP_BACKOFF_BASE = 0.5
+    HTTP_BACKOFF_MAX = 4.0
 
     def __init__(self):
         """Initialize database manager with appropriate storage location."""
@@ -68,12 +77,55 @@ class DatabaseManager:
         """Log to stderr for visibility in MCP clients."""
         print(message, file=sys.stderr, end=end, flush=True)
 
+    def _http_get_with_retry(self, url: str, timeout: int = 30) -> requests.Response:
+        """GET ``url`` with exponential backoff on transient failures.
+
+        Retries on connection errors, timeouts, and 5xx responses up to
+        ``HTTP_RETRY_ATTEMPTS`` times. 4xx responses raise immediately — those
+        are not transient and retrying won't help.
+        """
+        last_exc: Exception | None = None
+        for attempt in range(self.HTTP_RETRY_ATTEMPTS):
+            try:
+                response = requests.get(url, timeout=timeout)
+            except requests.exceptions.RequestException as e:
+                last_exc = e
+            else:
+                if response.status_code < 500:
+                    response.raise_for_status()  # raises on 4xx, no-op on 2xx/3xx
+                    return response
+                last_exc = requests.exceptions.HTTPError(
+                    f"HTTP {response.status_code} for {url}"
+                )
+
+            if attempt + 1 < self.HTTP_RETRY_ATTEMPTS:
+                backoff = min(
+                    self.HTTP_BACKOFF_BASE * (2**attempt), self.HTTP_BACKOFF_MAX
+                )
+                # Jitter ±50% so retried clients don't synchronize against a flaky origin.
+                backoff *= 0.5 + random.random()
+                self._log(
+                    f"\n  ⚠️  Request failed ({last_exc}); "
+                    f"retrying in {backoff:.1f}s "
+                    f"(attempt {attempt + 2}/{self.HTTP_RETRY_ATTEMPTS})..."
+                )
+                time.sleep(backoff)
+
+        assert last_exc is not None  # loop body always sets last_exc on failure
+        raise last_exc
+
     def _download_database(self) -> None:
         """Download and build the JLCPCB database from upstream manifest + shards.
 
         Builds into a sibling ``*.tmp`` file and atomically renames on success so
-        a crashed or interrupted build never leaves a half-populated database in
-        place of a working one.
+        a *process crash* never leaves a partial DB at the final path — observers
+        always see either the previous DB or a fully-built new one.
+
+        Subcategory-level errors (failed shard download, malformed shard header,
+        etc.) are still logged and skipped per existing design, so a "successful"
+        build can silently omit subcategories that errored. That's a separate
+        concern from atomicity and is tracked via the per-subcategory warning
+        log lines.
         """
         self.data_dir.mkdir(parents=True, exist_ok=True)
 
@@ -96,8 +148,7 @@ class DatabaseManager:
             # Download manifest
             self._log("📥 Step 1/4: Downloading manifest...")
             manifest_url = f"{self.DB_BASE_URL}/{self.MANIFEST_FILENAME}"
-            response = requests.get(manifest_url, timeout=30)
-            response.raise_for_status()
+            response = self._http_get_with_retry(manifest_url, timeout=30)
             manifest = response.json()
 
             manifest_version = manifest.get("version")
@@ -116,8 +167,7 @@ class DatabaseManager:
             self._log("📥 Step 2/4: Downloading attributes lookup table...")
             lut_filename = manifest.get("attributesLut", self.ATTR_LUT_FILENAME)
             lut_url = f"{self.DB_BASE_URL}/{lut_filename}"
-            lut_response = requests.get(lut_url, timeout=60)
-            lut_response.raise_for_status()
+            lut_response = self._http_get_with_retry(lut_url, timeout=60)
             lut = json.loads(gzip.decompress(lut_response.content))
             self._log(f"✓ LUT downloaded ({len(lut)} entries)")
             self._log("")
@@ -200,8 +250,7 @@ class DatabaseManager:
             schema maps field names ("lcsc", "stock", ...) to their integer index.
         """
         shard_url = f"{self.DB_BASE_URL}/{shard_filename}"
-        response = requests.get(shard_url, timeout=60)
-        response.raise_for_status()
+        response = self._http_get_with_retry(shard_url, timeout=60)
 
         text = gzip.decompress(response.content).decode("utf-8")
         lines = text.splitlines()

--- a/src/jlcpcb_mcp/database.py
+++ b/src/jlcpcb_mcp/database.py
@@ -17,7 +17,9 @@ class DatabaseManager:
 
     DB_BASE_URL = "https://yaqwsx.github.io/jlcparts/data"
     DB_FILENAME = "components.sqlite"
-    INDEX_FILENAME = "index.json"
+    MANIFEST_FILENAME = "manifest.json"
+    ATTR_LUT_FILENAME = "attributes-lut.json.gz"
+    MANIFEST_VERSION = 2
 
     def __init__(self):
         """Initialize database manager with appropriate storage location."""
@@ -67,7 +69,7 @@ class DatabaseManager:
         print(message, file=sys.stderr, end=end, flush=True)
 
     def _download_database(self) -> None:
-        """Download and build the JLCPCB database from JSON sources."""
+        """Download and build the JLCPCB database from upstream manifest + shards."""
         self.data_dir.mkdir(parents=True, exist_ok=True)
 
         self._log("=" * 70)
@@ -80,63 +82,73 @@ class DatabaseManager:
         self._log("")
 
         try:
-            # Download index
-            self._log("📥 Step 1/3: Downloading component index...")
-            index_url = f"{self.DB_BASE_URL}/{self.INDEX_FILENAME}"
-            response = requests.get(index_url, timeout=30)
+            # Download manifest
+            self._log("📥 Step 1/4: Downloading manifest...")
+            manifest_url = f"{self.DB_BASE_URL}/{self.MANIFEST_FILENAME}"
+            response = requests.get(manifest_url, timeout=30)
             response.raise_for_status()
-            index = response.json()
-            self._log("✓ Index downloaded")
+            manifest = response.json()
+
+            manifest_version = manifest.get("version")
+            if manifest_version != self.MANIFEST_VERSION:
+                self._log(
+                    f"⚠️  Manifest version {manifest_version} differs from expected "
+                    f"{self.MANIFEST_VERSION}; attempting to proceed."
+                )
+            self._log(
+                f"✓ Manifest downloaded ({len(manifest['categories'])} subcategories, "
+                f"{manifest.get('totalComponents', '?')} components)"
+            )
+            self._log("")
+
+            # Download attributes LUT
+            self._log("📥 Step 2/4: Downloading attributes lookup table...")
+            lut_filename = manifest.get("attributesLut", self.ATTR_LUT_FILENAME)
+            lut_url = f"{self.DB_BASE_URL}/{lut_filename}"
+            lut_response = requests.get(lut_url, timeout=60)
+            lut_response.raise_for_status()
+            lut = json.loads(gzip.decompress(lut_response.content))
+            self._log(f"✓ LUT downloaded ({len(lut)} entries)")
             self._log("")
 
             # Create database
-            self._log("🔨 Step 2/3: Creating database schema...")
+            self._log("🔨 Step 3/4: Creating database schema...")
             self._create_database_schema()
             self._log("✓ Schema created")
             self._log("")
 
-            # Get connection
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
 
-            # Process categories
-            categories = index.get("categories", {})
-            total_categories = sum(len(subcats) for subcats in categories.values())
-            processed = 0
-
-            self._log(f"📦 Step 3/3: Downloading and processing {total_categories} categories...")
+            categories = manifest["categories"]
+            total_subcats = len(categories)
+            self._log(f"📦 Step 4/4: Downloading and processing {total_subcats} subcategories...")
             self._log("This is the slow part - downloading ~50MB of component data...")
             self._log("")
 
-            for main_cat, subcategories in categories.items():
-                for subcat_name, subcat_info in subcategories.items():
-                    processed += 1
-                    sourcename = subcat_info["sourcename"]
+            for processed, subcat in enumerate(categories, start=1):
+                cat_name = subcat["category"]
+                subcat_name = subcat["subcategory"]
+                shards = subcat.get("shards", [])
 
-                    percent = (processed / total_categories) * 100
-                    self._log(
-                        f"\r[{processed}/{total_categories}] ({percent:.1f}%) {main_cat} / {subcat_name}...",
-                        end="",
-                    )
+                percent = (processed / total_subcats) * 100
+                self._log(
+                    f"\r[{processed}/{total_subcats}] ({percent:.1f}%) {cat_name} / {subcat_name}...",
+                    end="",
+                )
 
-                    # Download category JSON (gzipped)
-                    cat_url = f"{self.DB_BASE_URL}/{sourcename}.json.gz"
-                    try:
-                        response = requests.get(cat_url, timeout=30)
-                        response.raise_for_status()
+                try:
+                    for shard_filename in shards:
+                        rows, schema = self._fetch_shard(shard_filename)
+                        self._insert_components(
+                            cursor, rows, schema, lut, cat_name, subcat_name
+                        )
+                    # Commit per subcategory so a mid-build crash leaves a partial-but-valid DB.
+                    conn.commit()
+                except Exception as e:
+                    self._log(f"\n  ⚠️  Warning: Failed to process {subcat_name}: {e}")
+                    continue
 
-                        # Decompress and parse JSON
-                        data = json.loads(gzip.decompress(response.content))
-
-                        # Insert components
-                        self._insert_components(cursor, data, main_cat, subcat_name)
-
-                    except Exception as e:
-                        self._log(f"\n  ⚠️  Warning: Failed to process {subcat_name}: {e}")
-                        continue
-
-            # Commit and close
-            conn.commit()
             conn.close()
 
             self._log("\n")
@@ -151,14 +163,36 @@ class DatabaseManager:
             with open(self.version_file, "w") as f:
                 f.write(f"Downloaded: {datetime.now().isoformat()}\n")
                 f.write(f"Source: {self.DB_BASE_URL}\n")
-                f.write(f"Categories: {total_categories}\n")
+                f.write(f"Manifest version: {manifest_version}\n")
+                f.write(f"Subcategories: {total_subcats}\n")
+                f.write(f"Total components: {manifest.get('totalComponents', 'unknown')}\n")
 
         except Exception as e:
             self._log(f"\n❌ Error building database: {e}")
-            # Clean up failed database
             if self.db_path.exists():
                 self.db_path.unlink()
             raise
+
+    def _fetch_shard(self, shard_filename: str) -> tuple[list, dict]:
+        """
+        Download and parse a single component shard.
+
+        Returns:
+            (rows, schema) — rows is a list of positional component arrays;
+            schema maps field names ("lcsc", "stock", ...) to their integer index.
+        """
+        shard_url = f"{self.DB_BASE_URL}/{shard_filename}"
+        response = requests.get(shard_url, timeout=60)
+        response.raise_for_status()
+
+        text = gzip.decompress(response.content).decode("utf-8")
+        lines = text.splitlines()
+        if not lines:
+            return [], {}
+
+        schema = json.loads(lines[0])
+        rows = [json.loads(line) for line in lines[1:] if line]
+        return rows, schema
 
     def _create_database_schema(self) -> None:
         """Create the SQLite database schema."""
@@ -206,52 +240,63 @@ class DatabaseManager:
         conn.close()
 
     def _insert_components(
-        self, cursor: sqlite3.Cursor, data: dict, main_cat: str, subcat: str
+        self,
+        cursor: sqlite3.Cursor,
+        rows: list,
+        schema: dict,
+        lut: list,
+        main_cat: str,
+        subcat: str,
     ) -> None:
-        """Insert components from a category JSON into the database."""
-        components = data.get("components", [])
+        """Insert components from one or more shard rows into the database."""
+        # Resolve schema indices once per shard.
+        idx_lcsc = schema.get("lcsc", 0)
+        idx_mfr = schema.get("mfr", 1)
+        idx_description = schema.get("description")
+        idx_datasheet = schema.get("datasheet")
+        idx_price = schema.get("price")
+        idx_img = schema.get("img")
+        idx_attributes = schema.get("attributes")
+        idx_stock = schema.get("stock")
 
-        for comp in components:
+        for row in rows:
             try:
-                # Parse component array
-                # [lcsc, mfr_part, stock, ?, datasheet, price_tiers, image, ?, attributes]
-                lcsc = comp[0]
-                mfr_part = comp[1]
-                stock = comp[2]
-                datasheet = comp[4] if len(comp) > 4 else None
-                price_tiers = comp[5] if len(comp) > 5 else []
-                image = comp[6] if len(comp) > 6 else None
-                attributes = comp[8] if len(comp) > 8 else {}
+                lcsc = row[idx_lcsc]
+                mfr_part = row[idx_mfr]
+                description = row[idx_description] if idx_description is not None else None
+                stock = row[idx_stock] if idx_stock is not None else None
+                datasheet = row[idx_datasheet] if idx_datasheet is not None else None
+                price_tiers = row[idx_price] if idx_price is not None else []
+                image = row[idx_img] if idx_img is not None else None
+                attr_ids = row[idx_attributes] if idx_attributes is not None else []
 
-                # Extract useful attributes
+                attributes = self._resolve_attributes(attr_ids, lut)
+
                 basic = 0
                 manufacturer = None
                 package = None
-                description = None
 
-                if isinstance(attributes, dict):
-                    # Check if Basic or Extended
-                    basic_attr = attributes.get("Basic/Extended", {})
-                    if isinstance(basic_attr, dict):
-                        values = basic_attr.get("values", {}).get("default", [])
-                        if values and values[0] == "Basic":
-                            basic = 1
+                # Check if Basic or Extended
+                basic_attr = attributes.get("Basic/Extended", {})
+                if isinstance(basic_attr, dict):
+                    values = basic_attr.get("values", {}).get("default", [])
+                    if values and values[0] == "Basic":
+                        basic = 1
 
-                    # Get manufacturer
-                    mfr_attr = attributes.get("Manufacturer", {})
-                    if isinstance(mfr_attr, dict):
-                        values = mfr_attr.get("values", {}).get("default", [])
-                        if values:
-                            manufacturer = values[0]
+                # Get manufacturer
+                mfr_attr = attributes.get("Manufacturer", {})
+                if isinstance(mfr_attr, dict):
+                    values = mfr_attr.get("values", {}).get("default", [])
+                    if values:
+                        manufacturer = values[0]
 
-                    # Get package
-                    pkg_attr = attributes.get("Package", {})
-                    if isinstance(pkg_attr, dict):
-                        values = pkg_attr.get("values", {}).get("default", [])
-                        if values:
-                            package = values[0]
+                # Get package
+                pkg_attr = attributes.get("Package", {})
+                if isinstance(pkg_attr, dict):
+                    values = pkg_attr.get("values", {}).get("default", [])
+                    if values:
+                        package = values[0]
 
-                # Insert component
                 cursor.execute(
                     """
                     INSERT OR REPLACE INTO components
@@ -275,7 +320,6 @@ class DatabaseManager:
                     ),
                 )
 
-                # Insert price tiers
                 if isinstance(price_tiers, list):
                     for tier in price_tiers:
                         if isinstance(tier, dict):
@@ -290,6 +334,23 @@ class DatabaseManager:
             except Exception:
                 # Skip malformed components
                 continue
+
+    @staticmethod
+    def _resolve_attributes(attr_ids: list, lut: list) -> dict:
+        """Resolve a list of LUT integer IDs into the legacy attributes dict shape."""
+        attributes: dict = {}
+        if not isinstance(attr_ids, list):
+            return attributes
+        for aid in attr_ids:
+            if not isinstance(aid, int) or aid < 0 or aid >= len(lut):
+                continue
+            entry = lut[aid]
+            if not isinstance(entry, list) or len(entry) < 2:
+                continue
+            name, value = entry[0], entry[1]
+            if isinstance(name, str):
+                attributes[name] = value
+        return attributes
 
     def _verify_database(self) -> bool:
         """

--- a/src/jlcpcb_mcp/database.py
+++ b/src/jlcpcb_mcp/database.py
@@ -111,8 +111,10 @@ class DatabaseManager:
                 )
                 time.sleep(backoff)
 
-        assert last_exc is not None  # loop body always sets last_exc on failure
-        raise last_exc
+        # The loop only exits without returning when last_exc was set on every
+        # iteration; the `or` is belt-and-suspenders for the unreachable case so
+        # `python -O` (which strips asserts) can't surface a `raise None` TypeError.
+        raise last_exc or RuntimeError("retry loop exited without an exception")
 
     def _download_database(self) -> None:
         """Download and build the JLCPCB database from upstream manifest + shards.

--- a/src/jlcpcb_mcp/database.py
+++ b/src/jlcpcb_mcp/database.py
@@ -69,8 +69,18 @@ class DatabaseManager:
         print(message, file=sys.stderr, end=end, flush=True)
 
     def _download_database(self) -> None:
-        """Download and build the JLCPCB database from upstream manifest + shards."""
+        """Download and build the JLCPCB database from upstream manifest + shards.
+
+        Builds into a sibling ``*.tmp`` file and atomically renames on success so
+        a crashed or interrupted build never leaves a half-populated database in
+        place of a working one.
+        """
         self.data_dir.mkdir(parents=True, exist_ok=True)
+
+        # Build into a temporary path; rename to the final location only on success.
+        tmp_path = self.db_path.with_name(self.db_path.name + ".tmp")
+        if tmp_path.exists():
+            tmp_path.unlink()
 
         self._log("=" * 70)
         self._log("🔧 FIRST RUN: Building JLCPCB Component Database")
@@ -81,6 +91,7 @@ class DatabaseManager:
         self._log("Future searches will be instant!")
         self._log("")
 
+        conn: sqlite3.Connection | None = None
         try:
             # Download manifest
             self._log("📥 Step 1/4: Downloading manifest...")
@@ -111,13 +122,13 @@ class DatabaseManager:
             self._log(f"✓ LUT downloaded ({len(lut)} entries)")
             self._log("")
 
-            # Create database
+            # Create schema in the tmp DB
             self._log("🔨 Step 3/4: Creating database schema...")
-            self._create_database_schema()
+            self._create_database_schema(tmp_path)
             self._log("✓ Schema created")
             self._log("")
 
-            conn = sqlite3.connect(self.db_path)
+            conn = sqlite3.connect(tmp_path)
             cursor = conn.cursor()
 
             categories = manifest["categories"]
@@ -143,13 +154,17 @@ class DatabaseManager:
                         self._insert_components(
                             cursor, rows, schema, lut, cat_name, subcat_name
                         )
-                    # Commit per subcategory so a mid-build crash leaves a partial-but-valid DB.
                     conn.commit()
                 except Exception as e:
                     self._log(f"\n  ⚠️  Warning: Failed to process {subcat_name}: {e}")
                     continue
 
             conn.close()
+            conn = None
+
+            # Atomically swap tmp into place. Any prior DB is replaced wholesale;
+            # callers that crashed mid-build never observe a half-built DB.
+            tmp_path.replace(self.db_path)
 
             self._log("\n")
             self._log("=" * 70)
@@ -169,9 +184,12 @@ class DatabaseManager:
 
         except Exception as e:
             self._log(f"\n❌ Error building database: {e}")
-            if self.db_path.exists():
-                self.db_path.unlink()
+            if tmp_path.exists():
+                tmp_path.unlink()
             raise
+        finally:
+            if conn is not None:
+                conn.close()
 
     def _fetch_shard(self, shard_filename: str) -> tuple[list, dict]:
         """
@@ -194,9 +212,10 @@ class DatabaseManager:
         rows = [json.loads(line) for line in lines[1:] if line]
         return rows, schema
 
-    def _create_database_schema(self) -> None:
-        """Create the SQLite database schema."""
-        conn = sqlite3.connect(self.db_path)
+    def _create_database_schema(self, target_path: Path | None = None) -> None:
+        """Create the SQLite database schema at ``target_path`` (defaults to ``self.db_path``)."""
+        path = target_path if target_path is not None else self.db_path
+        conn = sqlite3.connect(path)
         cursor = conn.cursor()
 
         # Components table
@@ -248,10 +267,16 @@ class DatabaseManager:
         main_cat: str,
         subcat: str,
     ) -> None:
-        """Insert components from one or more shard rows into the database."""
-        # Resolve schema indices once per shard.
-        idx_lcsc = schema.get("lcsc", 0)
-        idx_mfr = schema.get("mfr", 1)
+        """Insert components from one or more shard rows into the database.
+
+        Raises ``KeyError`` if the shard schema header is missing the required
+        ``lcsc`` or ``mfr`` fields — caller catches per-subcategory and skips.
+        """
+        # Resolve schema indices once per shard. lcsc/mfr are required; their
+        # absence means the shard header is malformed and we should bail rather
+        # than silently misalign positional reads.
+        idx_lcsc = schema["lcsc"]
+        idx_mfr = schema["mfr"]
         idx_description = schema.get("description")
         idx_datasheet = schema.get("datasheet")
         idx_price = schema.get("price")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -374,19 +374,22 @@ class TestDatabaseManager:
 
     @patch("jlcpcb_mcp.database.requests.get")
     def test_download_database_network_error(self, mock_get, tmp_path):
-        """Test handling of network errors during download."""
-        mock_get.side_effect = Exception("Network error")
+        """A failed manifest fetch propagates and leaves no database behind."""
+        import requests as _requests
+
+        mock_get.side_effect = _requests.exceptions.ConnectionError("Network error")
 
         manager = DatabaseManager()
         manager.db_path = tmp_path / "components.sqlite"
         manager.data_dir = tmp_path
         manager.version_file = tmp_path / "version.txt"
 
-        with pytest.raises(Exception):
+        with pytest.raises(_requests.exceptions.RequestException):
             manager._download_database()
 
-        # Database should be cleaned up on error
+        # Neither the final DB nor the temp scratch file should remain.
         assert not manager.db_path.exists()
+        assert not (tmp_path / "components.sqlite.tmp").exists()
 
     def test_insert_components_with_attributes_json(self, tmp_path):
         """Test that attributes are reconstructed from the LUT and stored as JSON."""
@@ -538,3 +541,125 @@ class TestDatabaseManager:
 
         # Version metadata should record the manifest version.
         assert "Manifest version: 2" in manager.version_file.read_text()
+
+        # Tmp scratch file should not be left behind after a successful build.
+        assert not (tmp_path / "components.sqlite.tmp").exists()
+
+    def test_download_database_multi_shard_subcategory(self, tmp_path, monkeypatch):
+        """A single subcategory split across multiple shards ingests all components."""
+        manifest = {
+            "version": 2,
+            "totalComponents": 2,
+            "attributesLut": "attributes-lut.json.gz",
+            "categories": [
+                {
+                    "id": 1,
+                    "category": "Resistors",
+                    "subcategory": "Chip Resistor",
+                    "componentCount": 2,
+                    "shards": [
+                        "components-resistors__abcd1234-001.jsonl.gz",
+                        "components-resistors__abcd1234-002.jsonl.gz",
+                    ],
+                }
+            ],
+        }
+        lut = [_attr("Basic/Extended", "Basic")]
+
+        def make_shard(lcsc: str) -> bytes:
+            lines = [
+                json.dumps(SHARD_SCHEMA),
+                json.dumps(
+                    [lcsc, f"MFR-{lcsc}", 2, "desc", None, [], None, None, [0], 100, 1]
+                ),
+            ]
+            return gzip.compress(("\n".join(lines)).encode("utf-8"))
+
+        shard_a = make_shard("C100")
+        shard_b = make_shard("C200")
+        lut_bytes = gzip.compress(json.dumps(lut).encode("utf-8"))
+
+        def fake_get(url, timeout=None):
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            if url.endswith("/manifest.json"):
+                resp.json = MagicMock(return_value=manifest)
+            elif url.endswith("/attributes-lut.json.gz"):
+                resp.content = lut_bytes
+            elif url.endswith("-001.jsonl.gz"):
+                resp.content = shard_a
+            elif url.endswith("-002.jsonl.gz"):
+                resp.content = shard_b
+            else:
+                raise AssertionError(f"unexpected URL {url}")
+            return resp
+
+        monkeypatch.setattr("jlcpcb_mcp.database.requests.get", fake_get)
+
+        manager = DatabaseManager()
+        manager.db_path = tmp_path / "components.sqlite"
+        manager.data_dir = tmp_path
+        manager.version_file = tmp_path / "version.txt"
+
+        manager._download_database()
+
+        conn = sqlite3.connect(manager.db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT lcsc FROM components ORDER BY lcsc")
+        assert [row[0] for row in cursor.fetchall()] == ["C100", "C200"]
+        conn.close()
+
+    def test_download_database_proceeds_on_unknown_manifest_version(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """A manifest with an unexpected version logs a warning but still builds."""
+        manifest = {
+            "version": 99,  # not MANIFEST_VERSION
+            "totalComponents": 1,
+            "attributesLut": "attributes-lut.json.gz",
+            "categories": [
+                {
+                    "id": 1,
+                    "category": "Resistors",
+                    "subcategory": "Chip Resistor",
+                    "componentCount": 1,
+                    "shards": ["components-resistors__abcd1234-001.jsonl.gz"],
+                }
+            ],
+        }
+        lut = [_attr("Basic/Extended", "Basic")]
+        shard_lines = [
+            json.dumps(SHARD_SCHEMA),
+            json.dumps(["C1", "M1", 2, "d", None, [], None, None, [0], 1, 1]),
+        ]
+        shard_bytes = gzip.compress(("\n".join(shard_lines)).encode("utf-8"))
+        lut_bytes = gzip.compress(json.dumps(lut).encode("utf-8"))
+
+        def fake_get(url, timeout=None):
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            if url.endswith("/manifest.json"):
+                resp.json = MagicMock(return_value=manifest)
+            elif url.endswith("/attributes-lut.json.gz"):
+                resp.content = lut_bytes
+            else:
+                resp.content = shard_bytes
+            return resp
+
+        monkeypatch.setattr("jlcpcb_mcp.database.requests.get", fake_get)
+
+        manager = DatabaseManager()
+        manager.db_path = tmp_path / "components.sqlite"
+        manager.data_dir = tmp_path
+        manager.version_file = tmp_path / "version.txt"
+
+        manager._download_database()
+
+        # Build proceeded.
+        conn = sqlite3.connect(manager.db_path)
+        assert conn.execute("SELECT COUNT(*) FROM components").fetchone()[0] == 1
+        conn.close()
+
+        # Warning was logged to stderr.
+        captured = capsys.readouterr()
+        assert "Manifest version 99" in captured.err

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -6,6 +6,7 @@ import sqlite3
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from jlcpcb_mcp.database import DatabaseManager
 
@@ -373,18 +374,18 @@ class TestDatabaseManager:
         assert not version_file.exists()
 
     @patch("jlcpcb_mcp.database.requests.get")
-    def test_download_database_network_error(self, mock_get, tmp_path):
-        """A failed manifest fetch propagates and leaves no database behind."""
-        import requests as _requests
-
-        mock_get.side_effect = _requests.exceptions.ConnectionError("Network error")
+    def test_download_database_network_error(self, mock_get, tmp_path, monkeypatch):
+        """A persistent network failure propagates and leaves no database behind."""
+        # Make retries instant so the test doesn't actually sleep.
+        monkeypatch.setattr("jlcpcb_mcp.database.time.sleep", lambda *_: None)
+        mock_get.side_effect = requests.exceptions.ConnectionError("Network error")
 
         manager = DatabaseManager()
         manager.db_path = tmp_path / "components.sqlite"
         manager.data_dir = tmp_path
         manager.version_file = tmp_path / "version.txt"
 
-        with pytest.raises(_requests.exceptions.RequestException):
+        with pytest.raises(requests.exceptions.RequestException):
             manager._download_database()
 
         # Neither the final DB nor the temp scratch file should remain.
@@ -495,6 +496,7 @@ class TestDatabaseManager:
         def fake_get(url, timeout=None):
             resp = MagicMock()
             resp.raise_for_status = MagicMock()
+            resp.status_code = 200
             if url.endswith("/manifest.json"):
                 resp.json = MagicMock(return_value=manifest)
             elif url.endswith("/attributes-lut.json.gz"):
@@ -582,6 +584,7 @@ class TestDatabaseManager:
         def fake_get(url, timeout=None):
             resp = MagicMock()
             resp.raise_for_status = MagicMock()
+            resp.status_code = 200
             if url.endswith("/manifest.json"):
                 resp.json = MagicMock(return_value=manifest)
             elif url.endswith("/attributes-lut.json.gz"):
@@ -638,6 +641,7 @@ class TestDatabaseManager:
         def fake_get(url, timeout=None):
             resp = MagicMock()
             resp.raise_for_status = MagicMock()
+            resp.status_code = 200
             if url.endswith("/manifest.json"):
                 resp.json = MagicMock(return_value=manifest)
             elif url.endswith("/attributes-lut.json.gz"):
@@ -663,3 +667,231 @@ class TestDatabaseManager:
         # Warning was logged to stderr.
         captured = capsys.readouterr()
         assert "Manifest version 99" in captured.err
+
+    def test_insert_components_raises_on_missing_lcsc_in_schema(self, tmp_path):
+        """A shard header missing the required `lcsc` field bails immediately."""
+        db_path = tmp_path / "components.sqlite"
+        manager = DatabaseManager()
+        manager.db_path = db_path
+        manager.data_dir = tmp_path
+        manager._create_database_schema()
+
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+
+        bad_schema = {"mfr": 0, "stock": 1}  # no "lcsc"
+        rows = [["does", "not", "matter"]]
+
+        with pytest.raises(KeyError):
+            manager._insert_components(cursor, rows, bad_schema, [], "Cat", "Sub")
+
+        conn.close()
+
+    def test_download_database_skips_subcategory_with_malformed_shard_header(
+        self, tmp_path, monkeypatch
+    ):
+        """A bad shard header skips its subcategory but does not abort the build."""
+        monkeypatch.setattr("jlcpcb_mcp.database.time.sleep", lambda *_: None)
+        manifest = {
+            "version": 2,
+            "totalComponents": 1,
+            "attributesLut": "attributes-lut.json.gz",
+            "categories": [
+                {
+                    "id": 1,
+                    "category": "Good",
+                    "subcategory": "Subcat-A",
+                    "componentCount": 1,
+                    "shards": ["good.jsonl.gz"],
+                },
+                {
+                    "id": 2,
+                    "category": "Bad",
+                    "subcategory": "Subcat-B",
+                    "componentCount": 1,
+                    "shards": ["bad.jsonl.gz"],
+                },
+            ],
+        }
+        lut = [_attr("Basic/Extended", "Basic")]
+        good_shard = gzip.compress(
+            (
+                json.dumps(SHARD_SCHEMA)
+                + "\n"
+                + json.dumps(["C1", "M1", 2, "d", None, [], None, None, [0], 1, 1])
+            ).encode("utf-8")
+        )
+        # Header lacks the required `lcsc` field.
+        bad_schema = dict(SHARD_SCHEMA)
+        bad_schema.pop("lcsc")
+        bad_shard = gzip.compress(
+            (json.dumps(bad_schema) + "\n" + json.dumps(["x"] * 11)).encode("utf-8")
+        )
+        lut_bytes = gzip.compress(json.dumps(lut).encode("utf-8"))
+
+        def fake_get(url, timeout=None):
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.status_code = 200
+            if url.endswith("/manifest.json"):
+                resp.json = MagicMock(return_value=manifest)
+            elif url.endswith("/attributes-lut.json.gz"):
+                resp.content = lut_bytes
+            elif url.endswith("/good.jsonl.gz"):
+                resp.content = good_shard
+            elif url.endswith("/bad.jsonl.gz"):
+                resp.content = bad_shard
+            else:
+                raise AssertionError(f"unexpected URL {url}")
+            return resp
+
+        monkeypatch.setattr("jlcpcb_mcp.database.requests.get", fake_get)
+
+        manager = DatabaseManager()
+        manager.db_path = tmp_path / "components.sqlite"
+        manager.data_dir = tmp_path
+        manager.version_file = tmp_path / "version.txt"
+
+        manager._download_database()
+
+        # Good shard ingested; bad shard skipped silently (per design).
+        conn = sqlite3.connect(manager.db_path)
+        assert [r[0] for r in conn.execute("SELECT lcsc FROM components")] == ["C1"]
+        conn.close()
+
+    def test_download_database_closes_connection_on_failure(
+        self, tmp_path, monkeypatch
+    ):
+        """An exception after the build connection opens still closes it via the finally."""
+        monkeypatch.setattr("jlcpcb_mcp.database.time.sleep", lambda *_: None)
+
+        # Manifest contains a malformed category — `subcat["category"]` is accessed
+        # outside the inner per-subcategory try, so the KeyError propagates and we
+        # rely on the outer try/finally to close the build connection.
+        manifest = {
+            "version": 2,
+            "totalComponents": 0,
+            "attributesLut": "attributes-lut.json.gz",
+            "categories": [{"id": 1, "componentCount": 0, "shards": []}],  # no "category" key
+        }
+        lut_bytes = gzip.compress(json.dumps([]).encode("utf-8"))
+
+        def fake_get(url, timeout=None):
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.status_code = 200
+            if url.endswith("/manifest.json"):
+                resp.json = MagicMock(return_value=manifest)
+            elif url.endswith("/attributes-lut.json.gz"):
+                resp.content = lut_bytes
+            else:
+                raise AssertionError(f"unexpected URL {url}")
+            return resp
+
+        monkeypatch.setattr("jlcpcb_mcp.database.requests.get", fake_get)
+
+        # Wrap sqlite3.connect so we can observe close() calls. sqlite3.Connection
+        # itself doesn't allow attribute assignment, so we use a delegating proxy.
+        closed_paths: list[str] = []
+        real_connect = sqlite3.connect
+
+        class TrackingConn:
+            def __init__(self, real_conn, path):
+                object.__setattr__(self, "_real_conn", real_conn)
+                object.__setattr__(self, "_path", str(path))
+
+            def close(self):
+                closed_paths.append(self._path)
+                return self._real_conn.close()
+
+            def __getattr__(self, name):
+                return getattr(self._real_conn, name)
+
+        def tracking_connect(path, *args, **kwargs):
+            return TrackingConn(real_connect(path, *args, **kwargs), path)
+
+        monkeypatch.setattr("jlcpcb_mcp.database.sqlite3.connect", tracking_connect)
+
+        manager = DatabaseManager()
+        manager.db_path = tmp_path / "components.sqlite"
+        manager.data_dir = tmp_path
+        manager.version_file = tmp_path / "version.txt"
+
+        with pytest.raises(KeyError):
+            manager._download_database()
+
+        # The build conn opened on the tmp path must have been closed before cleanup.
+        assert any(p.endswith("components.sqlite.tmp") for p in closed_paths)
+        # And the tmp file should be gone.
+        assert not (tmp_path / "components.sqlite.tmp").exists()
+
+    # ---- HTTP retry/backoff (issue #6) ----
+
+    def test_http_get_with_retry_succeeds_after_transient_5xx(self, monkeypatch):
+        """Two 503s followed by a 200 should produce a successful response."""
+        sleeps: list[float] = []
+        monkeypatch.setattr("jlcpcb_mcp.database.time.sleep", lambda s: sleeps.append(s))
+
+        attempts = []
+
+        def fake_get(url, timeout=None):
+            attempts.append(url)
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            if len(attempts) < 3:
+                resp.status_code = 503
+            else:
+                resp.status_code = 200
+            return resp
+
+        monkeypatch.setattr("jlcpcb_mcp.database.requests.get", fake_get)
+
+        manager = DatabaseManager()
+        result = manager._http_get_with_retry("http://example/foo", timeout=5)
+
+        assert result.status_code == 200
+        assert len(attempts) == 3
+        assert len(sleeps) == 2  # slept between attempts 1→2 and 2→3, not after 3
+
+    def test_http_get_with_retry_fails_fast_on_4xx(self, monkeypatch):
+        """A 404 raises immediately without retrying — it's not transient."""
+        sleeps: list[float] = []
+        monkeypatch.setattr("jlcpcb_mcp.database.time.sleep", lambda s: sleeps.append(s))
+
+        attempts = []
+
+        def fake_get(url, timeout=None):
+            attempts.append(url)
+            resp = MagicMock()
+            resp.status_code = 404
+            resp.raise_for_status = MagicMock(
+                side_effect=requests.exceptions.HTTPError("404 Not Found")
+            )
+            return resp
+
+        monkeypatch.setattr("jlcpcb_mcp.database.requests.get", fake_get)
+
+        manager = DatabaseManager()
+        with pytest.raises(requests.exceptions.HTTPError):
+            manager._http_get_with_retry("http://example/missing", timeout=5)
+
+        assert len(attempts) == 1
+        assert sleeps == []
+
+    def test_http_get_with_retry_exhausts_attempts(self, monkeypatch):
+        """Persistent connection errors raise after HTTP_RETRY_ATTEMPTS tries."""
+        monkeypatch.setattr("jlcpcb_mcp.database.time.sleep", lambda *_: None)
+
+        attempts = []
+
+        def fake_get(url, timeout=None):
+            attempts.append(url)
+            raise requests.exceptions.ConnectionError("boom")
+
+        monkeypatch.setattr("jlcpcb_mcp.database.requests.get", fake_get)
+
+        manager = DatabaseManager()
+        with pytest.raises(requests.exceptions.ConnectionError):
+            manager._http_get_with_retry("http://example/down", timeout=5)
+
+        assert len(attempts) == DatabaseManager.HTTP_RETRY_ATTEMPTS

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -895,3 +895,31 @@ class TestDatabaseManager:
             manager._http_get_with_retry("http://example/down", timeout=5)
 
         assert len(attempts) == DatabaseManager.HTTP_RETRY_ATTEMPTS
+
+    def test_http_get_with_retry_fails_fast_on_4xx_after_5xx(self, monkeypatch):
+        """A 404 mid-retry-sequence aborts immediately — non-retryable interrupts retry."""
+        monkeypatch.setattr("jlcpcb_mcp.database.time.sleep", lambda *_: None)
+
+        attempts = []
+
+        def fake_get(url, timeout=None):
+            attempts.append(url)
+            resp = MagicMock()
+            if len(attempts) == 1:
+                resp.status_code = 503
+                resp.raise_for_status = MagicMock()
+            else:
+                resp.status_code = 404
+                resp.raise_for_status = MagicMock(
+                    side_effect=requests.exceptions.HTTPError("404 Not Found")
+                )
+            return resp
+
+        monkeypatch.setattr("jlcpcb_mcp.database.requests.get", fake_get)
+
+        manager = DatabaseManager()
+        with pytest.raises(requests.exceptions.HTTPError):
+            manager._http_get_with_retry("http://example/x", timeout=5)
+
+        # One retry happened (after the 503), then the 404 aborted the loop.
+        assert len(attempts) == 2

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,13 +1,40 @@
 """Unit tests for DatabaseManager."""
 
+import gzip
 import json
 import sqlite3
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from jlcpcb_mcp.database import DatabaseManager
+
+# Reusable shard schema header — line 1 of every upstream JSONL shard.
+SHARD_SCHEMA = {
+    "lcsc": 0,
+    "mfr": 1,
+    "joints": 2,
+    "description": 3,
+    "datasheet": 4,
+    "price": 5,
+    "img": 6,
+    "url": 7,
+    "attributes": 8,
+    "stock": 9,
+    "subcategory": 10,
+}
+
+
+def _attr(name: str, value: str) -> list:
+    """Build a single LUT entry in the upstream shape."""
+    return [
+        name,
+        {
+            "format": "${default}",
+            "primary": "default",
+            "values": {"default": [value, "string"]},
+        },
+    ]
 
 
 class TestDatabaseManager:
@@ -166,40 +193,35 @@ class TestDatabaseManager:
         conn = sqlite3.connect(db_path)
         cursor = conn.cursor()
 
-        # Sample component data (format from jlcparts JSON)
-        component_data = {
-            "components": [
-                [
-                    "C17976",  # lcsc
-                    "1206W4F680JT5E",  # mfr_part
-                    33900,  # stock
-                    None,  # unknown field
-                    "https://datasheet.lcsc.com/test.pdf",  # datasheet
-                    [  # price tiers
-                        {"qFrom": 1, "qTo": 99, "price": 0.005},
-                        {"qFrom": 100, "qTo": 999, "price": 0.0037},
-                    ],
-                    "https://assets.lcsc.com/image.jpg",  # image
-                    None,  # unknown field
-                    {  # attributes
-                        "Basic/Extended": {
-                            "values": {"default": ["Basic"]}
-                        },
-                        "Manufacturer": {
-                            "values": {"default": ["Uniroyal Elec"]}
-                        },
-                        "Package": {
-                            "values": {"default": ["1206"]}
-                        },
-                    },
-                ]
+        lut = [
+            _attr("Basic/Extended", "Basic"),
+            _attr("Manufacturer", "Uniroyal Elec"),
+            _attr("Package", "1206"),
+        ]
+        rows = [
+            [
+                "C17976",  # lcsc
+                "1206W4F680JT5E",  # mfr
+                2,  # joints
+                "68Ω 250mW 1206 Chip Resistor",  # description
+                "https://datasheet.lcsc.com/test.pdf",  # datasheet
+                [  # price tiers
+                    {"qFrom": 1, "qTo": 99, "price": 0.005},
+                    {"qFrom": 100, "qTo": 999, "price": 0.0037},
+                ],
+                "https://assets.lcsc.com/image.jpg",  # img
+                "products/C17976",  # url
+                [0, 1, 2],  # attribute LUT ids
+                33900,  # stock
+                1,  # subcategory id
             ]
-        }
+        ]
 
-        manager._insert_components(cursor, component_data, "Resistors", "Chip Resistor")
+        manager._insert_components(
+            cursor, rows, SHARD_SCHEMA, lut, "Resistors", "Chip Resistor"
+        )
         conn.commit()
 
-        # Verify component was inserted
         cursor.execute("SELECT * FROM components WHERE lcsc = ?", ("C17976",))
         row = cursor.fetchone()
 
@@ -208,10 +230,12 @@ class TestDatabaseManager:
         assert row[1] == "1206W4F680JT5E"  # mfr_part
         assert row[2] == "Resistors"  # category
         assert row[3] == "Chip Resistor"  # subcategory
+        assert row[4] == "68Ω 250mW 1206 Chip Resistor"  # description (now populated)
         assert row[5] == 33900  # stock
         assert row[8] == 1  # basic flag
+        assert row[9] == "Uniroyal Elec"  # manufacturer
+        assert row[10] == "1206"  # package
 
-        # Verify price tiers were inserted
         cursor.execute("SELECT * FROM prices WHERE lcsc = ?", ("C17976",))
         prices = cursor.fetchall()
         assert len(prices) == 2
@@ -232,27 +256,24 @@ class TestDatabaseManager:
         conn = sqlite3.connect(db_path)
         cursor = conn.cursor()
 
-        component_data = {
-            "components": [
-                [
-                    "C123456",
-                    "TEST123",
-                    1000,
-                    None,
-                    None,
-                    [],
-                    None,
-                    None,
-                    {
-                        "Basic/Extended": {
-                            "values": {"default": ["Extended"]}
-                        },
-                    },
-                ]
+        lut = [_attr("Basic/Extended", "Extended")]
+        rows = [
+            [
+                "C123456",
+                "TEST123",
+                3,
+                "Test MCU",
+                None,
+                [],
+                None,
+                None,
+                [0],
+                1000,
+                42,
             ]
-        }
+        ]
 
-        manager._insert_components(cursor, component_data, "ICs", "MCU")
+        manager._insert_components(cursor, rows, SHARD_SCHEMA, lut, "ICs", "MCU")
         conn.commit()
 
         cursor.execute("SELECT basic FROM components WHERE lcsc = ?", ("C123456",))
@@ -275,20 +296,16 @@ class TestDatabaseManager:
         conn = sqlite3.connect(db_path)
         cursor = conn.cursor()
 
-        # Malformed component data
-        component_data = {
-            "components": [
-                ["C123"],  # Too few fields
-                None,  # Invalid type
-                [],  # Empty array
-            ]
-        }
+        rows = [
+            ["C123"],  # Too few fields — IndexError on access
+            None,  # Invalid type — TypeError on subscript
+            [],  # Empty array — IndexError on access
+        ]
 
-        # Should not raise exception
-        manager._insert_components(cursor, component_data, "Test", "Test")
+        # Should not raise
+        manager._insert_components(cursor, rows, SHARD_SCHEMA, [], "Test", "Test")
         conn.commit()
 
-        # No components should be inserted
         cursor.execute("SELECT COUNT(*) FROM components")
         count = cursor.fetchone()[0]
         assert count == 0
@@ -372,7 +389,7 @@ class TestDatabaseManager:
         assert not manager.db_path.exists()
 
     def test_insert_components_with_attributes_json(self, tmp_path):
-        """Test that attributes are properly stored as JSON."""
+        """Test that attributes are reconstructed from the LUT and stored as JSON."""
         db_path = tmp_path / "components.sqlite"
 
         manager = DatabaseManager()
@@ -383,36 +400,141 @@ class TestDatabaseManager:
         conn = sqlite3.connect(db_path)
         cursor = conn.cursor()
 
-        attributes = {
-            "Resistance": {"values": {"resistance": [10000]}},
-            "Tolerance": {"values": {"default": ["±1%"]}},
-        }
-
-        component_data = {
-            "components": [
-                [
-                    "C17976",
-                    "TEST",
-                    1000,
-                    None,
-                    None,
-                    [],
-                    None,
-                    None,
-                    attributes,
-                ]
+        # LUT entries preserve nested value-dict shape, including non-default keys
+        # (e.g. "resistance") that server.py's json_extract relies on.
+        lut = [
+            ["Resistance", {"values": {"resistance": [10000, "number"]}}],
+            ["Tolerance", {"values": {"default": ["±1%", "string"]}}],
+        ]
+        rows = [
+            [
+                "C17976",
+                "TEST",
+                2,
+                "10kΩ ±1%",
+                None,
+                [],
+                None,
+                None,
+                [0, 1],
+                1000,
+                1,
             ]
-        }
+        ]
 
-        manager._insert_components(cursor, component_data, "Test", "Test")
+        manager._insert_components(cursor, rows, SHARD_SCHEMA, lut, "Test", "Test")
         conn.commit()
 
         cursor.execute("SELECT attributes FROM components WHERE lcsc = ?", ("C17976",))
         row = cursor.fetchone()
 
-        # Should be valid JSON string
         stored_attributes = json.loads(row[0])
         assert stored_attributes["Resistance"]["values"]["resistance"][0] == 10000
         assert stored_attributes["Tolerance"]["values"]["default"][0] == "±1%"
 
         conn.close()
+
+    def test_resolve_attributes_skips_invalid_ids(self):
+        """Out-of-range and non-int IDs should be silently dropped, not raise."""
+        lut = [["Package", {"values": {"default": ["0805", "string"]}}]]
+
+        result = DatabaseManager._resolve_attributes(
+            [0, 999, -1, "not-an-int", None], lut
+        )
+
+        assert "Package" in result
+        assert len(result) == 1
+
+    def test_download_database_parses_manifest_and_shards(self, tmp_path, monkeypatch):
+        """End-to-end test of the new manifest+LUT+shard ingest pipeline (mocked HTTP)."""
+        manifest = {
+            "version": 2,
+            "totalComponents": 1,
+            "attributesLut": "attributes-lut.json.gz",
+            "categories": [
+                {
+                    "id": 1,
+                    "category": "Resistors",
+                    "subcategory": "Chip Resistor",
+                    "componentCount": 1,
+                    "shards": ["components-resistors__abcd1234-001.jsonl.gz"],
+                }
+            ],
+        }
+
+        lut = [
+            _attr("Basic/Extended", "Basic"),
+            _attr("Manufacturer", "Uniroyal Elec"),
+            _attr("Package", "1206"),
+        ]
+
+        shard_lines = [
+            json.dumps(SHARD_SCHEMA),
+            json.dumps(
+                [
+                    "C17976",
+                    "1206W4F680JT5E",
+                    2,
+                    "68Ω 1206",
+                    "http://example/ds.pdf",
+                    [{"qFrom": 1, "qTo": 99, "price": 0.005}],
+                    "http://example/img.jpg",
+                    "products/C17976",
+                    [0, 1, 2],
+                    33900,
+                    1,
+                ]
+            ),
+        ]
+        shard_bytes = gzip.compress(("\n".join(shard_lines)).encode("utf-8"))
+        lut_bytes = gzip.compress(json.dumps(lut).encode("utf-8"))
+
+        def fake_get(url, timeout=None):
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            if url.endswith("/manifest.json"):
+                resp.json = MagicMock(return_value=manifest)
+            elif url.endswith("/attributes-lut.json.gz"):
+                resp.content = lut_bytes
+            elif url.endswith("/components-resistors__abcd1234-001.jsonl.gz"):
+                resp.content = shard_bytes
+            else:
+                raise AssertionError(f"unexpected URL {url}")
+            return resp
+
+        monkeypatch.setattr("jlcpcb_mcp.database.requests.get", fake_get)
+
+        manager = DatabaseManager()
+        manager.db_path = tmp_path / "components.sqlite"
+        manager.data_dir = tmp_path
+        manager.version_file = tmp_path / "version.txt"
+
+        manager._download_database()
+
+        conn = sqlite3.connect(manager.db_path)
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT lcsc, mfr_part, category, subcategory, description, stock, "
+            "basic, manufacturer, package FROM components"
+        )
+        rows = cursor.fetchall()
+        assert rows == [
+            (
+                "C17976",
+                "1206W4F680JT5E",
+                "Resistors",
+                "Chip Resistor",
+                "68Ω 1206",
+                33900,
+                1,
+                "Uniroyal Elec",
+                "1206",
+            )
+        ]
+
+        cursor.execute("SELECT qty_from, qty_to, price FROM prices WHERE lcsc=?", ("C17976",))
+        assert cursor.fetchall() == [(1, 99, 0.005)]
+        conn.close()
+
+        # Version metadata should record the manifest version.
+        assert "Manifest version: 2" in manager.version_file.read_text()


### PR DESCRIPTION
## Summary

Restores the database build after upstream `yaqwsx/jlcparts` switched to a sharded manifest format, plus the follow-on hardening from review.

**Format port (closes #4)**

- Upstream switched from `index.json` + per-category JSON files to `manifest.json` + per-subcategory sharded JSONL.gz files with an attributes LUT (commits [`3db7b5a`](https://github.com/yaqwsx/jlcparts/commit/3db7b5a), [`7f35a4b`](https://github.com/yaqwsx/jlcparts/commit/7f35a4b), 2026-04-26). Our old endpoints 404, breaking `--refresh-db`, the first-query auto-build, and the `refresh_database` MCP tool.
- Rewrote `_download_database()` and `_insert_components()` for the new format. Read each shard's schema header from line 1 rather than hardcoding indices; `lcsc`/`mfr` are now strict (a malformed header skips the subcategory rather than reading misaligned columns).
- Resolves attribute LUT IDs back into the legacy `{name: {format, primary, values}}` dict shape — **on-disk SQLite schema is unchanged** and `server.py`'s `json_extract` queries keep working without edits. Existing user databases keep working.
- New `description` column finally gets populated (was always NULL before). This roughly doubles the on-disk DB size (~917 MB → ~1.8 GB); README updated accordingly.

**Atomicity & robustness (review HIGH/MEDIUM)**

- Build into `*.sqlite.tmp`, atomically rename via `Path.replace()` on success. A process crash mid-build no longer leaves a half-populated DB at the final path.
- `try/finally` to close the build SQLite connection before any cleanup so we never `unlink` an open handle.
- Strict schema lookups for required `lcsc`/`mfr`; optional fields keep their defensive `.get()`.

**HTTP retry/backoff (closes #6)**

- New `_http_get_with_retry` helper on `DatabaseManager`: exponential backoff with ±50% jitter, up to `HTTP_RETRY_ATTEMPTS=3` attempts. Retries connection errors and 5xx; 4xx fails fast.
- Applies to all three upstream fetches (manifest, LUT, shards). A single transient 5xx no longer skips an entire subcategory.

## Test plan

- [x] `make lint` — clean
- [x] `make test-quick` — 79 pass (started at 68; added 11 new tests across format port, atomicity, retry, and coverage gaps)
- [x] Live smoke tests against real upstream (3x, including post-retry-helper) — manifest + 249k LUT entries + real shard, all fields populated, atomic rename works, tmp scratch cleaned
- [x] Confirmed `json_extract(attributes, '$.Manufacturer.values.default[0]')` etc. still resolve against new ingest output (no `server.py` changes)
- [x] **Full upstream catalog build** — 576,851 components in 3.8 min, ~1.8 GB final, zero subcategory failures, zero retry events. `description` populated on 81.5%, `manufacturer` and `package` populated on 100%. `json_extract($.Resistance.values.resistance[0])` resolves to a numeric value (parametric search confirmed working end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
