### PR TITLE
fix(server): voltage_rating filter now matches capacitors

### DIFF
--- a/src/jlcpcb_mcp/database.py
+++ b/src/jlcpcb_mcp/database.py
@@ -13,6 +13,39 @@ from pathlib import Path
 import platformdirs
 import requests
 
+# Schema definition shared by the production builder and tests so they can't
+# silently drift apart. Uses CREATE ... IF NOT EXISTS throughout so it is safe
+# to run against an existing DB.
+COMPONENTS_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS components (
+    lcsc TEXT PRIMARY KEY,
+    mfr_part TEXT,
+    category TEXT,
+    subcategory TEXT,
+    description TEXT,
+    stock INTEGER,
+    datasheet TEXT,
+    image TEXT,
+    basic INTEGER,
+    manufacturer TEXT,
+    package TEXT,
+    attributes TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_category ON components(category);
+CREATE INDEX IF NOT EXISTS idx_subcategory ON components(subcategory);
+CREATE INDEX IF NOT EXISTS idx_mfr_part ON components(mfr_part);
+CREATE INDEX IF NOT EXISTS idx_manufacturer ON components(manufacturer);
+CREATE INDEX IF NOT EXISTS idx_basic ON components(basic);
+CREATE TABLE IF NOT EXISTS prices (
+    lcsc TEXT,
+    qty_from INTEGER,
+    qty_to INTEGER,
+    price REAL,
+    FOREIGN KEY (lcsc) REFERENCES components(lcsc)
+);
+CREATE INDEX IF NOT EXISTS idx_prices_lcsc ON prices(lcsc);
+"""
+
 
 class DatabaseManager:
     """Manages the local JLCPCB component database."""
@@ -267,47 +300,10 @@ class DatabaseManager:
         """Create the SQLite database schema at ``target_path`` (defaults to ``self.db_path``)."""
         path = target_path if target_path is not None else self.db_path
         conn = sqlite3.connect(path)
-        cursor = conn.cursor()
-
-        # Components table
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS components (
-                lcsc TEXT PRIMARY KEY,
-                mfr_part TEXT,
-                category TEXT,
-                subcategory TEXT,
-                description TEXT,
-                stock INTEGER,
-                datasheet TEXT,
-                image TEXT,
-                basic INTEGER,
-                manufacturer TEXT,
-                package TEXT,
-                attributes TEXT
-            )
-        """)
-
-        # Create indexes for common queries
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_category ON components(category)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_subcategory ON components(subcategory)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_mfr_part ON components(mfr_part)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_manufacturer ON components(manufacturer)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_basic ON components(basic)")
-
-        # Price table (separate for normalization)
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS prices (
-                lcsc TEXT,
-                qty_from INTEGER,
-                qty_to INTEGER,
-                price REAL,
-                FOREIGN KEY (lcsc) REFERENCES components(lcsc)
-            )
-        """)
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_prices_lcsc ON prices(lcsc)")
-
-        conn.commit()
-        conn.close()
+        try:
+            conn.executescript(COMPONENTS_SCHEMA_SQL)
+        finally:
+            conn.close()
 
     def _insert_components(
         self,

--- a/src/jlcpcb_mcp/server.py
+++ b/src/jlcpcb_mcp/server.py
@@ -27,17 +27,24 @@ db_manager = DatabaseManager()
 # Upstream uses inconsistent names: capacitors store it under "Allowable voltage",
 # while "Voltage Rated"/"Voltage Rating" are speculative — kept in case upstream
 # adopts them later, but they currently match zero rows in the catalog.
-VOLTAGE_RATING_ATTRIBUTE_PATHS = [
+VOLTAGE_RATING_ATTRIBUTE_PATHS: tuple[tuple[str, str], ...] = (
     ("Voltage Rated", "voltage rated"),
     ("Voltage Rating", "voltage rating"),
     ("Allowable voltage", "voltage"),  # capacitors
-]
+)
 
 
 def _voltage_rating_clause(voltage_v: float) -> tuple[str, list[float]]:
-    """Build a SQL OR-clause matching any known rated-voltage attribute path."""
+    """Build a SQL OR-clause matching any known rated-voltage attribute path.
+
+    The CAST(... AS REAL) is defensive: if upstream ever stores a voltage as
+    a string (e.g. "25V"), SQLite's default mixed-type comparison treats TEXT
+    as greater than NUMERIC, which would make every string row match every
+    numeric threshold and silently accept under-rated parts. CAST forces a
+    numeric comparison and parses leading numerics, so "25V" → 25.0.
+    """
     parts = [
-        f'json_extract(attributes, \'$."{name}".values."{vkey}"[0]\') >= ?'
+        f'CAST(json_extract(attributes, \'$."{name}".values."{vkey}"[0]\') AS REAL) >= ?'
         for name, vkey in VOLTAGE_RATING_ATTRIBUTE_PATHS
     ]
     return "(" + " OR ".join(parts) + ")", [voltage_v] * len(VOLTAGE_RATING_ATTRIBUTE_PATHS)

--- a/src/jlcpcb_mcp/server.py
+++ b/src/jlcpcb_mcp/server.py
@@ -21,6 +21,27 @@ mcp = FastMCP("jlcpcb-search")
 # Initialize database manager
 db_manager = DatabaseManager()
 
+# Each entry: (attribute_name, value_key). Queried as
+# `$."{name}".values."{vkey}"[0]`. Multiple entries are OR'd together so
+# categories that store rated voltage under different attribute names all match.
+# Upstream uses inconsistent names: capacitors store it under "Allowable voltage",
+# while "Voltage Rated"/"Voltage Rating" are speculative — kept in case upstream
+# adopts them later, but they currently match zero rows in the catalog.
+VOLTAGE_RATING_ATTRIBUTE_PATHS = [
+    ("Voltage Rated", "voltage rated"),
+    ("Voltage Rating", "voltage rating"),
+    ("Allowable voltage", "voltage"),  # capacitors
+]
+
+
+def _voltage_rating_clause(voltage_v: float) -> tuple[str, list[float]]:
+    """Build a SQL OR-clause matching any known rated-voltage attribute path."""
+    parts = [
+        f'json_extract(attributes, \'$."{name}".values."{vkey}"[0]\') >= ?'
+        for name, vkey in VOLTAGE_RATING_ATTRIBUTE_PATHS
+    ]
+    return "(" + " OR ".join(parts) + ")", [voltage_v] * len(VOLTAGE_RATING_ATTRIBUTE_PATHS)
+
 
 class LiveAPIClient:
     """Client for fetching live stock and pricing data from JLCPCB."""
@@ -209,12 +230,10 @@ def search_components(search: SearchQuery) -> str:
     if search.voltage_rating:
         voltage_v = parse_voltage(search.voltage_rating)
         if voltage_v:
-            # Match voltage ratings >= requested (for safety margin)
-            conditions.append(
-                '(json_extract(attributes, \'$."Voltage Rated".values."voltage rated"[0]\') >= ? OR '
-                'json_extract(attributes, \'$."Voltage Rating".values."voltage rating"[0]\') >= ?)'
-            )
-            params.extend([voltage_v, voltage_v])
+            # Match voltage ratings >= requested (for safety margin).
+            sql_clause, sql_params = _voltage_rating_clause(voltage_v)
+            conditions.append(sql_clause)
+            params.extend(sql_params)
 
     # Parametric search - power rating
     if search.power_rating:

--- a/tests/test_server_search.py
+++ b/tests/test_server_search.py
@@ -10,6 +10,7 @@ import sqlite3
 
 import pytest
 
+from jlcpcb_mcp.database import COMPONENTS_SCHEMA_SQL
 from jlcpcb_mcp.server import (
     VOLTAGE_RATING_ATTRIBUTE_PATHS,
     _voltage_rating_clause,
@@ -17,24 +18,9 @@ from jlcpcb_mcp.server import (
 
 
 def _make_components_db() -> sqlite3.Connection:
-    """Build a tiny in-memory components table mirroring the real schema."""
+    """Build an in-memory components DB using the production schema."""
     conn = sqlite3.connect(":memory:")
-    conn.execute("""
-        CREATE TABLE components (
-            lcsc TEXT PRIMARY KEY,
-            mfr_part TEXT,
-            category TEXT,
-            subcategory TEXT,
-            description TEXT,
-            stock INTEGER,
-            datasheet TEXT,
-            image TEXT,
-            basic INTEGER,
-            manufacturer TEXT,
-            package TEXT,
-            attributes TEXT
-        )
-    """)
+    conn.executescript(COMPONENTS_SCHEMA_SQL)
     return conn
 
 

--- a/tests/test_server_search.py
+++ b/tests/test_server_search.py
@@ -1,0 +1,134 @@
+"""Unit tests for SQL fragments built by `server.search_components`.
+
+These exercise the SQL builders against an in-memory SQLite that mimics the
+real schema, so we catch JSON-path regressions without needing to spin up a
+FastMCP context or hit the live API.
+"""
+
+import json
+import sqlite3
+
+import pytest
+
+from jlcpcb_mcp.server import (
+    VOLTAGE_RATING_ATTRIBUTE_PATHS,
+    _voltage_rating_clause,
+)
+
+
+def _make_components_db() -> sqlite3.Connection:
+    """Build a tiny in-memory components table mirroring the real schema."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute("""
+        CREATE TABLE components (
+            lcsc TEXT PRIMARY KEY,
+            mfr_part TEXT,
+            category TEXT,
+            subcategory TEXT,
+            description TEXT,
+            stock INTEGER,
+            datasheet TEXT,
+            image TEXT,
+            basic INTEGER,
+            manufacturer TEXT,
+            package TEXT,
+            attributes TEXT
+        )
+    """)
+    return conn
+
+
+def _attr(name: str, value, vkey: str = "default", vtype: str = "string"):
+    """LUT-style attribute entry, mirroring what database.py reconstructs."""
+    return name, {
+        "format": "${default}",
+        "primary": vkey,
+        "values": {vkey: [value, vtype]},
+    }
+
+
+def _insert_cap(conn, lcsc: str, capacitance_f: float, allowable_voltage: float):
+    """Insert a representative capacitor row with the upstream attribute shape."""
+    name1, val1 = _attr("Capacitance", capacitance_f, vkey="capacitance", vtype="number")
+    name2, val2 = _attr("Allowable voltage", allowable_voltage, vkey="voltage", vtype="number")
+    attrs = {name1: val1, name2: val2}
+    conn.execute(
+        "INSERT INTO components (lcsc, mfr_part, category, subcategory, attributes) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (lcsc, f"FAKE-{lcsc}", "Capacitors",
+         "Multilayer Ceramic Capacitors MLCC - SMD/SMT", json.dumps(attrs)),
+    )
+
+
+class TestVoltageRatingClause:
+    """Regression coverage for issue #8."""
+
+    def test_clause_includes_allowable_voltage_path(self):
+        """The Allowable voltage path must be in the OR chain — caps depend on it."""
+        sql, _params = _voltage_rating_clause(10.0)
+        assert '"Allowable voltage".values."voltage"' in sql
+
+    def test_clause_param_count_matches_path_count(self):
+        """Each OR'd path needs its own bind parameter."""
+        sql, params = _voltage_rating_clause(10.0)
+        assert sql.count("?") == len(VOLTAGE_RATING_ATTRIBUTE_PATHS)
+        assert params == [10.0] * len(VOLTAGE_RATING_ATTRIBUTE_PATHS)
+
+    def test_capacitor_with_allowable_voltage_matches_filter(self):
+        """A 10µF cap rated 10V should match voltage_rating=10V (regression for #8)."""
+        conn = _make_components_db()
+        _insert_cap(conn, "C5189822", capacitance_f=10e-6, allowable_voltage=10.0)
+        _insert_cap(conn, "C18185759", capacitance_f=10e-6, allowable_voltage=25.0)
+        conn.commit()
+
+        sql_clause, params = _voltage_rating_clause(10.0)
+        rows = conn.execute(
+            f"SELECT lcsc FROM components WHERE {sql_clause} ORDER BY lcsc",
+            params,
+        ).fetchall()
+
+        # Both caps rated >= 10V should match.
+        assert [r[0] for r in rows] == ["C18185759", "C5189822"]
+
+    def test_capacitor_below_threshold_excluded(self):
+        """A cap rated 6.3V must NOT match voltage_rating=10V."""
+        conn = _make_components_db()
+        _insert_cap(conn, "C-low", capacitance_f=10e-6, allowable_voltage=6.3)
+        _insert_cap(conn, "C-high", capacitance_f=10e-6, allowable_voltage=16.0)
+        conn.commit()
+
+        sql_clause, params = _voltage_rating_clause(10.0)
+        rows = conn.execute(
+            f"SELECT lcsc FROM components WHERE {sql_clause}",
+            params,
+        ).fetchall()
+
+        assert [r[0] for r in rows] == ["C-high"]
+
+    @pytest.mark.parametrize(
+        "name,vkey",
+        VOLTAGE_RATING_ATTRIBUTE_PATHS,
+    )
+    def test_each_configured_path_is_independently_queryable(self, name, vkey):
+        """Every configured path should produce a working json_extract expression."""
+        conn = _make_components_db()
+        attrs = {
+            name: {
+                "format": "${default}",
+                "primary": vkey,
+                "values": {vkey: [25.0, "number"]},
+            }
+        }
+        conn.execute(
+            "INSERT INTO components (lcsc, attributes) VALUES (?, ?)",
+            ("C-test", json.dumps(attrs)),
+        )
+        conn.commit()
+
+        sql_clause, params = _voltage_rating_clause(10.0)
+        rows = conn.execute(
+            f"SELECT lcsc FROM components WHERE {sql_clause}", params
+        ).fetchall()
+        assert rows == [("C-test",)], (
+            f"path ({name}, {vkey}) didn't match a row that has it set"
+        )


### PR DESCRIPTION
## Summary

The `voltage_rating` filter on `search_components` silently returned zero rows for any capacitor query — the hardcoded JSON paths (`Voltage Rated` / `Voltage Rating`) don't exist anywhere in the upstream catalog. Capacitors store rated voltage under `Allowable voltage` with value key `voltage`.

**Reproduction (before this PR):**

```jsonc
{ "query": "capacitor", "capacitance": "10uF", "voltage_rating": "10V" }
```
→ `No components found matching 'capacitor'`

**After this PR**, the same query returns 5 in-stock 0805 caps rated 10–50V.

## Changes

- Extract the inline OR clause into `_voltage_rating_clause()` driven by a module-level `VOLTAGE_RATING_ATTRIBUTE_PATHS` list. Add `("Allowable voltage", "voltage")` — the actual cap path. Legacy `Voltage Rated`/`Voltage Rating` entries kept (cheap, future-proof if upstream adopts them).
- New `tests/test_server_search.py` with 7 tests covering the `Allowable voltage` path, param count invariant, the 10V threshold (>=10V matches, <10V excluded), and per-path queryability via parametrize. This also lays the foundation for future `server.py` SQL tests.

## Audit per issue #8 acceptance

Checked the other parametric filters against real DB data — they all hit real attributes:

| Filter | Hardcoded path | Real DB hits |
|---|---|---|
| `power_rating` | `Power.values.power` | 99k resistors |
| `input_voltage_min/max` | `Input voltage.values.default` | 9k components |
| `output_voltage` | `Output voltage.values.voltage` | 30k components |
| `output_current` | `Output current (max)` (current/current2) | 2k+ components |

No silent breakage there.

## Out of scope

TVS/zener/varistor voltage attributes (`Clamping voltage`, `Voltage - breakdown`, `Reverse stand-off voltage (vrwm)`) are intentionally **not** added to this filter — those are different semantics ("breakdown"/"withstand" vs "rated"). Belongs in a separate filter or category-aware logic if needed; out of scope for #8.

Closes #8.

## Test plan

- [x] `make lint` — clean
- [x] `make test-quick` — 86 pass (was 79; +7 new in `test_server_search.py`)
- [x] Real-data smoke test — `voltage_rating=10V` on 10µF/0805 caps now returns 5 rows; the previous `No components found` regression is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)